### PR TITLE
Fix issue #4

### DIFF
--- a/src/encode/builder.rs
+++ b/src/encode/builder.rs
@@ -68,12 +68,17 @@ impl<'a> Builder<'a> {
         let reserved = self.info.map_reserved_areas();
         // Iterate on bits and place corresponding modules on nonreserved indices.
         let bv: BitVec<u8, Msb0> = BitVec::from_vec(codewords);
+        let data_len = bv.len();
         let mut indices = crate::qrcode::IndexSequenceIter::new(self.size());
-        for bit in bv {
+        for (i, bit) in bv.into_iter().enumerate() {
             // Get the next non-reserved index
             let next_unreserved_index = indices.find(|&(i, j)| !reserved.get(i, j).unwrap());
             let Some(index) = next_unreserved_index else {
-                break;
+                panic!(
+                    "there is data to place, but no free indices left: failed at bit {} out of {}",
+                    i + 1,
+                    data_len
+                );
             };
             self.matrix.set(index.0, index.1, bit.into());
         }

--- a/src/qrcode.rs
+++ b/src/qrcode.rs
@@ -523,6 +523,16 @@ impl IndexSequenceIter {
             || !flowing_up && self.i == self.size as isize - 1 // Flowing down but at the bottom
             || (self.size as isize - 1 - self.j) % 2 == 0 // Even column from the right
     }
+
+    /// The offset caused by the fact that the vertical timing column would cause the zig-zag pattern to collapse into
+    /// a vertical line. Continue the zig-zag, but offset by 1 to the left when the timing column is left.
+    fn timing_column_offset(&self) -> usize {
+        if self.j <= 5 {
+            1
+        } else {
+            0
+        }
+    }
 }
 
 impl Iterator for IndexSequenceIter {
@@ -547,9 +557,12 @@ impl Iterator for IndexSequenceIter {
                 self.i += 1;
             }
         };
-        // If current is valid, return it; otherwise do another step. Temporarily going out of bounds is allowed.as
-        if current.0 >= 0 && current.1 >= 0 {
-            Some((current.0 as usize, current.1 as usize))
+        // If current is valid, return it; otherwise do another step. Temporarily going out of bounds is allowed.
+        if current.0 >= 0 && current.1 >= 1 {
+            Some((
+                current.0 as usize,
+                current.1 as usize - self.timing_column_offset(),
+            ))
         } else {
             self.next()
         }
@@ -624,19 +637,9 @@ mod test {
     }
 
     #[test]
-    fn index_seq_at_left_boundary() {
-        let mut seq = IndexSequenceIter::new(21);
-        // Advance until we reach the left
-        assert_eq!(seq.find(|(_, j)| *j == 0), Some((20, 0)));
-        assert_eq!(seq.next(), Some((19, 0)));
-        assert_eq!(seq.next(), Some((18, 0)));
-        assert_eq!(seq.next(), Some((17, 0)));
-    }
-
-    #[test]
     fn index_seq_last() {
         let mut seq = IndexSequenceIter::new(21);
-        seq.find(|(i, j)| *i == 0 && *j == 0).unwrap();
+        seq.find(|&(i, j)| i == 20 && j == 0).unwrap();
         assert_eq!(seq.next(), None);
     }
 }


### PR DESCRIPTION
This pull request fixes the issue that would cause some QR codes to be generated incorrectly.

As explained in my comments on the issue itself, the problem is that we are treating the zig-zag pattern with which bits are placed in the symbol as independent from the reserved areas of the symbol, simply generating the pattern abstractly and then skipping the indices that fall on reserved areas when we want to place the data bits.

This is correct except for the vertical timing pattern, which shift the whole zig-zag pattern to the left by 1 column. I fixed this by adding an offset to the indices we generate when we run into this pattern.